### PR TITLE
Fix for negative Magento stock amount.

### DIFF
--- a/Model/Observer/SubtractQuoteInventoryObserver.php
+++ b/Model/Observer/SubtractQuoteInventoryObserver.php
@@ -81,11 +81,12 @@ class SubtractQuoteInventoryObserver extends \Magento\CatalogInventory\Observer\
                 $items[$productId] += $childItem->getTotalQty();
 
                 $stockItem = $this->stockRegistry->getStockItem($productId);
+                $stockQty = max($stockItem->getQty(), 0);
                 if ($this->stockbaseStockManagement->isStockbaseProduct($productId) &&
-                    $items[$productId] > $stockItem->getQty()
+                    $items[$productId] > $stockQty
                 ) {
-                    $diff = $items[$productId] - $stockItem->getQty();
-                    $items[$productId] = $stockItem->getQty();
+                    $diff = $items[$productId] - $stockQty;
+                    $items[$productId] = $stockQty;
                     
                     $stockbaseAmount = $this->stockbaseStockManagement->getStockbaseStockAmount($productId);
                     if ($stockbaseAmount - $diff < 0) {


### PR DESCRIPTION
When the Stockbase Integration processes a product with negative Magento stock amount, it tries to increase the quantity of products ordered from Stockbase to match the missing Magento stock.
This fix makes the module treat negative stock the same as zero stock and order from the Stockbase only the amount of products required for the current order.